### PR TITLE
Adds a module to fix Godhome menus.

### DIFF
--- a/QoL/Modules/FixGodhomeMenus.cs
+++ b/QoL/Modules/FixGodhomeMenus.cs
@@ -1,0 +1,55 @@
+﻿using System.Reflection;
+using InControl;
+using JetBrains.Annotations;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+
+namespace QoL.Modules
+{
+    [UsedImplicitly]
+    public class FixGodhomeMenus : FauxMod
+    {
+        private ILHook _hook;
+
+        public override void Initialize()
+        {
+            Unload();
+            MethodInfo methodInfo = typeof(HollowKnightInputModule).GetMethod("SendButtonEventToSelectedObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            _hook = new ILHook(methodInfo, SendButtonEventToSelectedObject);
+        }
+
+        public override void Unload()
+        {
+            _hook?.Dispose();
+        }
+
+        private static void SendButtonEventToSelectedObject(ILContext il)
+        {
+            ILCursor c = new ILCursor(il).Goto(0);
+            ILLabel checkFlag = c.DefineLabel();
+
+            bool success = c.TryGotoNext
+            (
+                MoveType.After,
+                i => i.MatchLdnull(),
+                i => i.MatchCall<BindingSource>("op_Inequality"),
+                i => i.MatchBrfalse(out _)
+            );
+
+            if (success)
+            {
+                c.Emit(OpCodes.Ldarg_0);
+                c.Emit<HollowKnightInputModule>(OpCodes.Call, "get_AttackAction");
+                c.Emit<OneAxisInputControl>(OpCodes.Callvirt, "get_WasPressed");
+                c.Emit(OpCodes.Brfalse, checkFlag);
+                c.GotoNext
+                (
+                    i => i.MatchLdloc(2),
+                    i => i.MatchBrfalse(out _)
+                );
+                c.MarkLabel(checkFlag);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Not sure if you accept random pull reqs for things like this, but the QoL mod was a good fit as it has a few other fixes so I thought I might as well!

The Godhome menus have a vanilla bug that prevents them from being closed if your Left Mouse button is bound to Attack. The specific menus this bug affects are the Pantheon menus and the individual boss challenge menus.

This bug is due to a line in the `HollowKnightInputModule.SendButtonEventToSelectedObject()` method, where it checks to see if the `AttackAction` has a binding equal to `Mouse.LeftButton`, and if so, prevents the `ICancelHandler`'s cancel method from being called.

This fix adds a module that hooks that method and adds a secondary check that requires that the Attack button was also the button that was pressed.