### PR TITLE
 Fix NRE if CG1 is already dead

### DIFF
--- a/QoL/Modules/PatchedBosses.cs
+++ b/QoL/Modules/PatchedBosses.cs
@@ -69,6 +69,9 @@ namespace QoL.Modules
 
             GameObject miner = GameObject.Find("Mega Zombie Beam Miner (1)");
 
+            if (miner == null)
+                yield break;
+
             if (miner.LocateMyFSM("Beam Miner").TryGetState("Sleep", out FsmState? sleep))
                 sleep.Transitions = sleep.Transitions.Where(x => x.FsmEvent.Name != "EXTRA DAMAGED" && x.FsmEvent.Name != "TOOK DAMAGE").ToArray();
         }


### PR DESCRIPTION
(The Battle Scene in Ruins2_03_boss always spawns so we don't need to do the null check)