### PR TITLE
Modinterop

### DIFF
--- a/QoL/QoL.cs
+++ b/QoL/QoL.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using Modding;
+using MonoMod.ModInterop;
 using QoL.Modules;
 using Vasi;
 
@@ -13,6 +14,11 @@ namespace QoL
     [UsedImplicitly]
     public class QoL : Mod, ITogglableMod, IGlobalSettings<Settings>, ICustomMenuMod
     {
+        public QoL() : base(null)
+        {
+            typeof(SettingsOverride).ModInterop();
+        }
+
         public override string GetVersion() => VersionUtil.GetVersion<QoL>();
 
         internal static Settings GlobalSettings { get; private set; } = new();

--- a/QoL/SettingsOverride.cs
+++ b/QoL/SettingsOverride.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using MonoMod.ModInterop;
 using QoL.Modules;
 
 namespace QoL
 {
     [PublicAPI]
+    [ModExportName("QoL")]
     public static class SettingsOverride
     {
         private static readonly HashSet<string> _Modules;

--- a/QoL/SettingsOverride.cs
+++ b/QoL/SettingsOverride.cs
@@ -43,7 +43,7 @@ namespace QoL
 
             // If overridden to a state different than the original, swap it back to the original
             if (@override != orig)
-                toggle(key, @override);
+                toggle(key, orig);
         }
 
         public static void OverrideModuleToggle(string name, bool enable)


### PR DESCRIPTION
My usual way to import mods is to use a class like [this](https://gist.github.com/flibber-hk/4cb3ea0519fe3ebbe5e48c2513f249a1); the idea is that I can place it anywhere in my project and it will behave as if I had a reference to the mod. (The idea is that anyone can blindly copy and paste that file into their mod without having to rewrite any boilerplate.)

Possible changes:

* Have a separate class which holds the methods to be exported, rather than simply exporting the SettingsOverride type. I think I prefer it like that but it's probably more trouble than it's worth. That said you could include methods like
```cs
public static (bool, bool) TryGetModuleOverride(string module)
{
    bool overridden = SettingsOverride.TryGetModuleOverride(module, out bool enabled);
    return (overridden, enabled);
}
```
to allow consumers to use the TryGet methods without defining custom delegate types, though I'm not sure it's worth the effort.

* Run `typeof(SettingsOverride).ModInterop();` somewhere else. I personally like running in the instance constructor because it means that the methods are available at the start of Initialize for other mods.


In the course of testing this, I discovered the bug fixed by the second commit.