### PR TITLE
Inverted `SoulMasterPhaseTransitionSkip` toggle

### DIFF
--- a/QoL/Modules/SkipCutscenes.cs
+++ b/QoL/Modules/SkipCutscenes.cs
@@ -178,7 +178,7 @@ namespace QoL.Modules
         // https://github.com/fifty-six/HollowKnight.QoL/issues/31
         private static void MageLordPhaseTransitionSkip(On.GGCheckIfBossScene.orig_OnEnter orig, GGCheckIfBossScene self)
         {
-            if (SoulMasterPhaseTransitionSkip || !self.Owner.transform.name.Contains("Corpse Mage") || !self.Fsm.ActiveStateName.Contains("Quick Death?"))
+            if (!SoulMasterPhaseTransitionSkip || !self.Owner.transform.name.Contains("Corpse Mage") || !self.Fsm.ActiveStateName.Contains("Quick Death?"))
             {
                 orig(self);
                 return;


### PR DESCRIPTION
As a user I'd expect that when the `SoulMasterPhaseTransitionSkip` toggle is `true`, then the skip should be enabled. Instead it's the other way around. IIRC this PR should fix that, though I didn't build & test it myself.