### PR TITLE
Add 1.2.2.1 Wall Cling Storage to SpeedBroke

### DIFF
--- a/QoL/Modules/SpeedBroke.cs
+++ b/QoL/Modules/SpeedBroke.cs
@@ -37,7 +37,7 @@ namespace QoL.Modules
         public static bool Televator = true;
 
         [SerializeToSetting]
-        public static bool WallClingStorage = true;
+        public static bool WallClingStorage;
 
         [SerializeToSetting]
         public static bool ExplosionPogo = true;


### PR DESCRIPTION
- Allows remaining clinged off of walls
- Allows auto clinging after dash without wall L/R flags set (e.g. liquid WCS)
- Allows vertical transition WCS (doesn't require chaining due to faster transitions though)
- Prevents updating wall flag on collision exit
- Restores down dash cling backwards sprite bug