### PR TITLE
Allow slopeball with FixFireballs, make slopeball consistent on all framerates

### DIFF
--- a/QoL/Modules/FixFireballs.cs
+++ b/QoL/Modules/FixFireballs.cs
@@ -18,10 +18,9 @@ namespace QoL.Modules
 
             public override void Reset() => sendEvent = null;
 
-            public override void OnEnter()
-            {
-                fixedUpdate = false;
-            }
+            public override void OnEnter() => fixedUpdate = false;
+
+            public override void OnFixedUpdate() => fixedUpdate = true;
 
             public override void OnUpdate()
             {
@@ -30,11 +29,6 @@ namespace QoL.Modules
                     Finish();
                     Fsm.Event(sendEvent);
                 }
-            }
-
-            public override void OnFixedUpdate()
-            {
-                fixedUpdate = true;
             }
         }
 


### PR DESCRIPTION
This causes the fireball FSM to wait for the next Update after a physics frame to listen for collision events, which prevents fireballs from hitting walls behind you as before without side effects and makes slopeball consistent on high FPS.